### PR TITLE
fix: remove unused programs tab

### DIFF
--- a/src/containers/LearnerDashboardHeader/CollapsedHeader/CollapseMenuBody.jsx
+++ b/src/containers/LearnerDashboardHeader/CollapsedHeader/CollapseMenuBody.jsx
@@ -32,9 +32,6 @@ export const CollapseMenuBody = ({ isOpen }) => {
       <Button as="a" href="/" variant="inverse-primary">
         {formatMessage(messages.course)}
       </Button>
-      <Button as="a" href={urls.programsUrl()} variant="inverse-primary">
-        {formatMessage(messages.program)}
-      </Button>
       <Button
         as="a"
         href={urls.baseAppUrl(courseSearchUrl)}

--- a/src/containers/LearnerDashboardHeader/CollapsedHeader/__snapshots__/CollapseMenuBody.test.jsx.snap
+++ b/src/containers/LearnerDashboardHeader/CollapsedHeader/__snapshots__/CollapseMenuBody.test.jsx.snap
@@ -13,13 +13,6 @@ exports[`CollapseMenuBody render 1`] = `
   </Button>
   <Button
     as="a"
-    href="http://localhost:18000/dashboard/programs"
-    variant="inverse-primary"
-  >
-    Programs
-  </Button>
-  <Button
-    as="a"
     href="http://localhost:18000/courseSearchUrl"
     onClick={[MockFunction findCoursesNavDropdownClicked("http://localhost:18000/courseSearchUrl")]}
     variant="inverse-primary"
@@ -78,13 +71,6 @@ exports[`CollapseMenuBody render unauthenticated 1`] = `
     variant="inverse-primary"
   >
     Courses
-  </Button>
-  <Button
-    as="a"
-    href="http://localhost:18000/dashboard/programs"
-    variant="inverse-primary"
-  >
-    Programs
   </Button>
   <Button
     as="a"

--- a/src/containers/LearnerDashboardHeader/ExpandedHeader/__snapshots__/index.test.jsx.snap
+++ b/src/containers/LearnerDashboardHeader/ExpandedHeader/__snapshots__/index.test.jsx.snap
@@ -19,14 +19,6 @@ exports[`ExpandedHeader render 1`] = `
     <Button
       as="a"
       className="p-4"
-      href="programsUrl"
-      variant="inverse-primary"
-    >
-      Programs
-    </Button>
-    <Button
-      as="a"
-      className="p-4"
       href="http://localhost:18000/courseSearchUrl"
       onClick={[MockFunction findCoursesNavClicked("http://localhost:18000/courseSearchUrl")]}
       variant="inverse-primary"

--- a/src/containers/LearnerDashboardHeader/ExpandedHeader/index.jsx
+++ b/src/containers/LearnerDashboardHeader/ExpandedHeader/index.jsx
@@ -40,14 +40,6 @@ export const ExpandedHeader = () => {
         </Button>
         <Button
           as="a"
-          href={urls.programsUrl()}
-          variant="inverse-primary"
-          className="p-4"
-        >
-          {formatMessage(messages.program)}
-        </Button>
-        <Button
-          as="a"
           href={urls.baseAppUrl(courseSearchUrl)}
           variant="inverse-primary"
           className="p-4"

--- a/src/containers/LearnerDashboardHeader/ExpandedHeader/index.test.jsx
+++ b/src/containers/LearnerDashboardHeader/ExpandedHeader/index.test.jsx
@@ -5,7 +5,6 @@ import ExpandedHeader from '.';
 import { useIsCollapsed } from '../hooks';
 
 jest.mock('data/services/lms/urls', () => ({
-  programsUrl: () => 'programsUrl',
   baseAppUrl: url => (`http://localhost:18000${url}`),
 }));
 

--- a/src/data/services/lms/urls.js
+++ b/src/data/services/lms/urls.js
@@ -21,9 +21,6 @@ export const updateUrl = (base, url) => ((url == null || url.startsWith('http://
 export const baseAppUrl = (url) => updateUrl(getBaseUrl(), url);
 export const learningMfeUrl = (url) => updateUrl(getConfig().LEARNING_BASE_URL, url);
 
-// static view url
-const programsUrl = () => baseAppUrl('/dashboard/programs');
-
 export const creditPurchaseUrl = (courseId) => `${getEcommerceUrl()}/credit/checkout/${courseId}/`;
 export const creditRequestUrl = (providerId) => `${getApiUrl()}/credit/v1/providers/${providerId}/request/`;
 
@@ -37,6 +34,5 @@ export default StrictDict({
   event,
   getInitApiUrl,
   learningMfeUrl,
-  programsUrl,
   updateEmailSettings,
 });


### PR DESCRIPTION
This PR solves https://github.com/eduNEXT/eox-release/issues/111 

The Programs tab should be removed from the header.

Responsive
![image](https://github.com/user-attachments/assets/4cefe89d-bf1c-4b8d-9e6d-66c9d95d3051)

Desktop
![image](https://github.com/user-attachments/assets/cb900ba0-9604-4b95-bfef-8aee0944a7ff)


[JIRA](https://edunext.atlassian.net/browse/AP-1274)