### PR TITLE
feat: add button to about of EDU page

### DIFF
--- a/src/containers/LearnerDashboardHeader/CollapsedHeader/CollapseMenuBody.jsx
+++ b/src/containers/LearnerDashboardHeader/CollapsedHeader/CollapseMenuBody.jsx
@@ -40,6 +40,13 @@ export const CollapseMenuBody = ({ isOpen }) => {
       >
         {formatMessage(messages.discoverNew)}
       </Button>
+      <Button
+        as="a"
+        href="https://edu.utec.edu.uy/about/"
+        variant="inverse-primary"
+      >
+        {formatMessage(messages.aboutUs)}
+      </Button>
       <Button as="a" href={getConfig().SUPPORT_URL} variant="inverse-primary">
         {formatMessage(messages.help)}
       </Button>

--- a/src/containers/LearnerDashboardHeader/ExpandedHeader/index.jsx
+++ b/src/containers/LearnerDashboardHeader/ExpandedHeader/index.jsx
@@ -47,6 +47,14 @@ export const ExpandedHeader = () => {
         >
           {formatMessage(messages.discoverNew)}
         </Button>
+        <Button
+          as="a"
+          href="https://edu.utec.edu.uy/about/"
+          variant="inverse-primary"
+          className="p-4"
+        >
+          {formatMessage(messages.aboutUs)}
+        </Button>
         <span className="flex-grow-1" />
         <Button
           as="a"

--- a/src/containers/LearnerDashboardHeader/messages.js
+++ b/src/containers/LearnerDashboardHeader/messages.js
@@ -86,6 +86,11 @@ const messages = defineMessages({
     defaultMessage: 'New',
     description: 'The text announcing that an item in the user menu is New',
   },
+  aboutUs: {
+    id: 'learnerVariantDashboard.aboutUs',
+    defaultMessage: 'About of EDU',
+    description: 'Header link for switching to about us page.',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
This PR introduces a new navigation button in the Learner Dashboard MFE to direct users to the "About EDU" page.

## ✅ Main Change
Feature: Added a new button labeled "Acerca de EDU" to the header/navigation section of the frontend-app-learner-dashboard.

This enhancement improves the user experience by providing a direct link to institutional information, as requested by the client.

## Visual results
![Captura de pantalla de 2025-04-24 15-57-50](https://github.com/user-attachments/assets/87b17a94-2c7d-428d-947a-2ee7909a3ba8)
